### PR TITLE
Update WindowsServiceLifecycle.java

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -126,7 +126,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
         File executable = new File(home, "hudson.exe");
         if (!executable.exists())   executable = new File(home, "jenkins.exe");
 
-        int r = new LocalLauncher(task).launch().cmds(executable, "restart")
+        int r = new LocalLauncher(task).launch().cmds(executable, "restart!")
                 .stdout(task).pwd(home).join();
         if(r!=0)
             throw new IOException(baos.toString());


### PR DESCRIPTION
Changed from using the Windows service wrappers "restart" command to using "restart!". This resolves the issue of the service wrapper process killing itself as part of the non-atomic stop-wait-start handling of restart.

See JENKINS-22685 for further description of the issue, and see WinSW README "Restarting service from itself" for info on the "restart!" command.
